### PR TITLE
Complete transition to default CamelCase parser

### DIFF
--- a/canopeum_backend/pyproject.toml
+++ b/canopeum_backend/pyproject.toml
@@ -101,6 +101,9 @@ max-args = 7
 # At least same as max-complexity
 max-branches = 15
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"rest_framework.parsers".msg = "Use `djangorestframework_camel_case.parser` instead."
+
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
 show_column_numbers = true


### PR DESCRIPTION
Follow-up to #https://github.com/BesLogic/releaf-canopeum/pull/181 and https://github.com/BesLogic/releaf-canopeum/pull/187

Now everything uses the CamelParser

As the top-of-the-file TODO says:
> Still need to figure out why setting CamelCaseMultiPartParser as a DEFAULT_PARSER_CLASSES breaks *some* Views' API generation (adds multiple body params). Then we won't need to import these as it'll simply be default.