### PR TITLE
Fix various Site modal issues I found

### DIFF
--- a/canopeum_frontend/src/components/analytics/SiteSummaryActions.tsx
+++ b/canopeum_frontend/src/components/analytics/SiteSummaryActions.tsx
@@ -165,7 +165,7 @@ const SiteSummaryActions = ({ siteSummary, admins, onSiteChange, onSiteEdit }: P
           {administratorsSelection}
         </Dropdown.Menu>
         <Dropdown.Item onClick={() => onSiteEdit(siteSummary.id)}>
-          Edit Site Information
+          {translate('analytics.edit-site-info')}
         </Dropdown.Item>
         <Dropdown.Item onClick={onDeleteSiteClick}>Delete</Dropdown.Item>
       </Dropdown.Menu>

--- a/canopeum_frontend/src/components/analytics/batch-modal/CreateBatchModal.tsx
+++ b/canopeum_frontend/src/components/analytics/batch-modal/CreateBatchModal.tsx
@@ -205,12 +205,7 @@ const CreateBatchModal = ({ open, site, handleClose }: Props) => {
                   species =>
                     setBatch(current => ({
                       ...current,
-                      species: species.map(specie =>
-                        new Species({
-                          id: specie.id,
-                          quantity: specie.quantity,
-                        })
-                      ),
+                      species: species.map(specie => new Species(specie)),
                     })),
                   [],
                 )}
@@ -322,12 +317,7 @@ const CreateBatchModal = ({ open, site, handleClose }: Props) => {
                   species =>
                     setBatch(current => ({
                       ...current,
-                      seeds: species.map(specie =>
-                        new Seeds({
-                          id: specie.id,
-                          quantity: specie.quantity,
-                        })
-                      ),
+                      seeds: species.map(specie => new Seeds(specie)),
                     })),
                   [],
                 )}

--- a/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
+++ b/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
@@ -332,4 +332,5 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
     </Dialog>
   )
 }
+// eslint-disable-next-line max-lines -- Will resolve itself with https://github.com/BesLogic/releaf-canopeum/pull/193
 export default SiteModal

--- a/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
+++ b/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
@@ -83,7 +83,12 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
   const [siteImageURL, setSiteImageURL] = useState<string>()
 
   const fetchSite = useCallback(async () => {
-    if (!siteId) return
+    if (!siteId) {
+      // Clear the image that could come from having opened the modal with a previous site
+      setSiteImageURL(undefined)
+
+      return
+    }
 
     const siteDetail = await getApiClient().siteClient.detail(siteId)
     const dmsLat = siteDetail.coordinate.dmsLatitude
@@ -131,7 +136,11 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
     <Dialog fullWidth maxWidth='sm' onClose={(_, reason) => handleClose(reason)} open={open}>
       <DialogTitle>
         <div className='fs-5 text-capitalize m-auto text-center'>
-          {t('analytics.site-modal.create-site')}
+          {t(
+            siteId
+              ? 'analytics.edit-site-info'
+              : 'analytics.create-site',
+          )}
         </div>
       </DialogTitle>
 
@@ -317,7 +326,7 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
           {t('generic.cancel')}
         </button>
         <button className='btn btn-primary' onClick={() => handleClose('save', site)} type='button'>
-          {t('generic.subscribe')}
+          {t('generic.save')}
         </button>
       </DialogActions>
     </Dialog>

--- a/canopeum_frontend/src/locale/en/analytics.json
+++ b/canopeum_frontend/src/locale/en/analytics.json
@@ -1,6 +1,7 @@
 {
   "title": "Manage my Sites",
   "create-site": "Create a New Site",
+  "edit-site-info": "Edit Site Information",
   "average": "average",
   "batches_one": "batch",
   "batches_other": "batches",
@@ -23,6 +24,8 @@
   "visitors": "Visitors",
   "sponsored": "Sponsored",
   "unnamed-site": "Unnamed site",
+  "site-save-success": "Site saved successfully",
+  "site-save-error": "Error saving Site",
   "site-deleted": "Site {{siteName}} was successfully deleted.",
   "site-deleted-error": "There was a problem while trying to delete the site {{siteName}}...",
   "success-rate-chart": {
@@ -42,7 +45,6 @@
     "admins-saved": "Admins saved successfully for {{siteName}}!"
   },
   "site-modal": {
-    "create-site": "create site",
     "site-name": "site name",
     "site-type": "site type",
     "site-image": "project image or enterprise logo",

--- a/canopeum_frontend/src/locale/fr/analytics.json
+++ b/canopeum_frontend/src/locale/fr/analytics.json
@@ -1,6 +1,7 @@
 {
   "title": "Gérer mes Sites",
   "create-site": "Créer un Nouveau Site",
+  "edit-site-info": "Modifier les données d'un Site",
   "average": "moyenne",
   "batches_one": "lot",
   "batches_other": "lots",
@@ -26,6 +27,8 @@
   "unknown": "Inconnu",
   "admins-saved": "Administrateurs sauvegardés avec succès pour {{siteName}}!",
   "unnamed-site": "Site sans nom",
+  "site-save-success": "Site saved successfully",
+  "site-save-error": "Error saving Site",
   "site-deleted": "Le site {{siteName}} a été supprimé avec succès.",
   "site-deleted-error": "Un problème est survenu lors de la tentative de suppression du site {{siteName}}...",
   "success-rate-chart": {
@@ -45,7 +48,6 @@
     "admins-saved": "Administrateurs sauvegardés avec succès pour {{siteName}}!"
   },
   "site-modal": {
-    "create-site": "créer un site",
     "site-name": "nom du site",
     "site-type": "type de site",
     "site-image": "image du projet ou logo de l'entreprise",

--- a/canopeum_frontend/src/pages/Analytics.tsx
+++ b/canopeum_frontend/src/pages/Analytics.tsx
@@ -8,6 +8,7 @@ import SiteSuccessRatesChart from '@components/analytics/SiteSuccessRatesChart'
 import SiteSummaryCard from '@components/analytics/SiteSummaryCard'
 import { AuthenticationContext } from '@components/context/AuthenticationContext'
 import { LanguageContext } from '@components/context/LanguageContext'
+import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import { type SiteSummary, Species, type User } from '@services/api'
 import { assetFormatter } from '@utils/assetFormatter'
@@ -15,6 +16,7 @@ import { assetFormatter } from '@utils/assetFormatter'
 const Analytics = () => {
   const { t: translate } = useTranslation()
   const { formatDate } = useContext(LanguageContext)
+  const { openAlertSnackbar } = useContext(SnackbarContext)
   const { currentUser } = useContext(AuthenticationContext)
   const { getApiClient } = useApiClient()
 
@@ -50,23 +52,25 @@ const Analytics = () => {
         ? await assetFormatter(data.siteImage)
         : undefined
 
-      const { dmsLatitude } = data
-      const latitude =
-        // eslint-disable-next-line max-len -- string
-        `${dmsLatitude.degrees}°${dmsLatitude.minutes}'${dmsLatitude.seconds}.${dmsLatitude.miliseconds}"${dmsLatitude.cardinal}`
+      const species = data.species.map(specie => new Species(specie))
 
       const {
+        dmsLatitude,
         dmsLongitude,
         siteName,
         siteType,
         presentation,
         researchPartner,
         size,
-        species,
         visibleOnMap,
       } = data
+
+      const latitude =
+        // eslint-disable-next-line max-len -- This or `prefer-template`
+        `${dmsLatitude.degrees}°${dmsLatitude.minutes}'${dmsLatitude.seconds}.${dmsLatitude.miliseconds}"${dmsLatitude.cardinal}`
+
       const longitude =
-        // eslint-disable-next-line max-len -- string
+        // eslint-disable-next-line max-len -- This or `prefer-template`
         `${dmsLongitude.degrees}°${dmsLongitude.minutes}'${dmsLongitude.seconds}.${dmsLongitude.miliseconds}"${dmsLongitude.cardinal}`
 
       const response = siteId
@@ -79,7 +83,7 @@ const Analytics = () => {
           longitude,
           presentation,
           size,
-          species.map(specie => new Species({ id: specie.id, quantity: specie.quantity })),
+          species,
           researchPartner,
           visibleOnMap,
         )
@@ -91,16 +95,25 @@ const Analytics = () => {
           longitude,
           presentation,
           size,
-          species.map(specie => new Species({ id: specie.id, quantity: specie.quantity })),
+          species,
           researchPartner,
           visibleOnMap,
         )
 
-      void response.then(async () => setSiteSummaries(await getApiClient().summaryClient.all()))
+      response.then(async () => {
+        openAlertSnackbar(
+          translate('analytics.site-save-success'),
+        )
+        setIsModalOpen(false)
+        setSiteId(undefined)
+        setSiteSummaries(await getApiClient().summaryClient.all())
+      }).catch(() =>
+        openAlertSnackbar(
+          translate('analytics.site-save-error'),
+          { severity: 'error' },
+        )
+      )
     }
-
-    setIsModalOpen(false)
-    setSiteId(undefined)
   }
 
   const handleSiteEdit = (_siteId: number) => {


### PR DESCRIPTION
From https://teams.microsoft.com/l/message/19:3v6LLSxADDE_UGRewubhTGhsctwyNAjpx6Ar0_AvRwo1@thread.tacv2/1721294392056?tenantId=cd34c2c6-a4f8-4af1-bdd5-497e97626cae&groupId=167b0d82-f8ec-429e-944f-45e9c370f2e3&parentMessageId=1718288595402&teamName=Beslogic%20-%20ARBRES%20Philanthropy&channelName=General&createdTime=1721294392056

This PR fixes the following:
- Incorrect modal title when editing
- Incorrect text on the "Save" button
- "Edit Site Information" was not translated in French
- Fixed the Site image from an "Edit" from leaking into "New"
- Add a "status" snackbar to inform about success or failure. Don't close the modal on failure.
- Simplified `Seeds` and `Species` iterative constructor calls

Coordinates issues are fixed here: https://github.com/BesLogic/releaf-canopeum/pull/193
Other fields save issues are fixed here: https://github.com/BesLogic/releaf-canopeum/pull/192
Edit fields not being filled in by default is raised here: https://github.com/BesLogic/releaf-canopeum/issues/191