### PR TITLE
Fix extra site name in edit modal

### DIFF
--- a/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
+++ b/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
@@ -120,7 +120,6 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
           <div className='mb-3'>
             <label className='form-label text-capitalize' htmlFor='site-name'>
               {t('analytics.site-modal.site-name')}
-              {site.siteName}
             </label>
             <input
               className='form-control'


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b8c1a731-2b80-4fb1-9444-746ab3264b65)


After:
![image](https://github.com/user-attachments/assets/f8facb62-06e3-47d9-9435-5119db4e91ff)
