### PR TITLE
Re-use bg-color for image upload

### DIFF
--- a/canopeum_frontend/src/components/analytics/ImageUpload.scss
+++ b/canopeum_frontend/src/components/analytics/ImageUpload.scss
@@ -1,0 +1,11 @@
+@import '../../App.scss';
+
+.upload-button {
+  background-color: var(--bs-body-bg);
+}
+
+.upload-instruction {
+  background-color: var(--bs-body-bg);
+  border-radius: $border-radius;
+  padding: 0 0.5rem;
+}

--- a/canopeum_frontend/src/components/analytics/ImageUpload.tsx
+++ b/canopeum_frontend/src/components/analytics/ImageUpload.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions -- custom input label */
+import './ImageUpload.scss'
+
 import type { ChangeEvent, DragEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -51,8 +53,8 @@ const ImageUpload = ({ id, onChange, imageUrl }: Props) => {
         }}
       >
         <img alt='' src={UploadIcon} />
-        <div className='btn btn-outline-primary'>{t('generic.upload')}</div>
-        <div>{t('analytics.image-upload')}</div>
+        <div className='btn btn-outline-primary upload-button'>{t('generic.upload')}</div>
+        <div className='upload-instruction'>{t('analytics.image-upload')}</div>
       </label>
       <input
         accept={supportedFileTypes.join(',')}


### PR DESCRIPTION
As discussed on Teams: https://teams.microsoft.com/l/message/19:3v6LLSxADDE_UGRewubhTGhsctwyNAjpx6Ar0_AvRwo1@thread.tacv2/1727815532823?tenantId=cd34c2c6-a4f8-4af1-bdd5-497e97626cae&groupId=167b0d82-f8ec-429e-944f-45e9c370f2e3&parentMessageId=1727815532823&teamName=Beslogic%20-%20ARBRES%20Philanthropy&channelName=General&createdTime=1727815532823
Closes #261

Before:
![image](https://github.com/user-attachments/assets/fa9185c5-cfcf-4d71-a845-fe9a3e40f71e)

After:
![image](https://github.com/user-attachments/assets/245405a0-c6b0-4579-b620-4376e045fd92)
(hover)
![image](https://github.com/user-attachments/assets/0ab2511a-f93f-4f8e-a6ed-a8a725158655)
