### PR TITLE
fix broken translation due to missing automatic plural handling

### DIFF
--- a/canopeum_frontend/.eslintrc.cjs
+++ b/canopeum_frontend/.eslintrc.cjs
@@ -82,6 +82,9 @@ module.exports = {
         // We need to apply it directly on object literals to check for excess properties
         // https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks
         'no-autofix/no-relative-import-paths/no-relative-import-paths': 'off',
+        // i18next uses snake_case for special handling
+        // https://www.i18next.com/translation-function/plurals#singular-plural
+        camelcase: 'off',
       },
     },
   ],

--- a/canopeum_frontend/src/components/CreatePostWidget.tsx
+++ b/canopeum_frontend/src/components/CreatePostWidget.tsx
@@ -164,7 +164,7 @@ const CreatePostWidget = ({ siteId, addNewPost }: Props) => {
           <div className='max-words end-0 text-end' style={{ bottom: '-1.6rem' }}>
             <span>{postBodyNumberOfWords}/{MAXIMUM_WORDS_PER_POST}</span>
             <span className='ms-1'>
-              {translate('social.comments.words', { count: MAXIMUM_WORDS_PER_POST })}
+              {translate('social.comments.word', { count: MAXIMUM_WORDS_PER_POST })}
             </span>
           </div>
 

--- a/canopeum_frontend/src/components/social/PostCommentsDialog.tsx
+++ b/canopeum_frontend/src/components/social/PostCommentsDialog.tsx
@@ -165,7 +165,7 @@ const PostCommentsDialog = ({ open, postId, siteId, handleClose }: Props) => {
                   >
                     <span>{commentBodyNumberOfWords}/{MAXIMUM_WORDS_PER_COMMENT}</span>
                     <span className='ms-1'>
-                      {translate('social.comments.words', { count: MAXIMUM_WORDS_PER_COMMENT })}
+                      {translate('social.comments.word', { count: MAXIMUM_WORDS_PER_COMMENT })}
                     </span>
                   </div>
                 </div>

--- a/canopeum_frontend/src/locale/en/analytics.ts
+++ b/canopeum_frontend/src/locale/en/analytics.ts
@@ -3,6 +3,8 @@ export default {
   'create-site': 'Create a New Site',
   'edit-site-info': 'Edit Site Information',
   average: 'average',
+  batch_one: 'batch',
+  batch_other: 'batches',
   sufficient: 'sufficient',
   insufficient: 'insufficient',
   'table-row-1': 'batch name / ID',
@@ -27,9 +29,7 @@ export default {
   'success-rate-chart': {
     title: 'Average Annual Success Rate Per Site',
   },
-  batches: {
-    'batch-tracking': 'Batch Tracking',
-  },
+  'batch-tracking': 'Batch Tracking',
   'site-summary': {
     planted: 'Planted',
     survived: 'Survived',

--- a/canopeum_frontend/src/locale/en/social.ts
+++ b/canopeum_frontend/src/locale/en/social.ts
@@ -7,6 +7,8 @@ export default {
   },
   comments: {
     'leave-a-comment': 'Leave a Comment',
+    word_one: 'word',
+    word_other: 'words',
     comments: 'Comments',
     send: 'Send',
     'comment-body-required': 'Your comment cannot be empty.',

--- a/canopeum_frontend/src/locale/fr/analytics.ts
+++ b/canopeum_frontend/src/locale/fr/analytics.ts
@@ -5,6 +5,8 @@ export default {
   'create-site': 'Créer un Nouveau Site',
   'edit-site-info': "Modifier les données d'un Site",
   average: 'moyenne',
+  batch_one: 'lot',
+  batch_other: 'lots',
   sufficient: 'suffisant',
   insufficient: 'insuffisant',
   'table-row-1': 'nom du lot / ID',
@@ -29,9 +31,7 @@ export default {
   'success-rate-chart': {
     title: 'Taux De Réussite Annuel Moyen Par Site',
   },
-  batches: {
-    'batch-tracking': 'Suivi des Lots',
-  },
+  'batch-tracking': 'Suivi des Lots',
   'site-summary': {
     planted: 'Planté',
     survived: 'Survécu',

--- a/canopeum_frontend/src/locale/fr/social.ts
+++ b/canopeum_frontend/src/locale/fr/social.ts
@@ -9,6 +9,8 @@ export default {
   },
   comments: {
     'leave-a-comment': 'Laisser un Commentaire',
+    word_one: 'mot',
+    word_other: 'mots',
     comments: 'Commentaires',
     send: 'Envoyer',
     'comment-body-required': 'Votre commentaire ne peut pas être vide.',

--- a/canopeum_frontend/src/pages/Analytics.tsx
+++ b/canopeum_frontend/src/pages/Analytics.tsx
@@ -160,7 +160,7 @@ const Analytics = () => {
                 </span>
                 <span className='text-capitalize'>
                   {site.batches.length}{' '}
-                  {translate('analytics.batches', { count: site.batches.length })}
+                  {translate('analytics.batch', { count: site.batches.length })}
                 </span>
               </div>
             </button>
@@ -223,7 +223,7 @@ const Analytics = () => {
         <div className='mt-4'>
           <div className='bg-cream rounded p-3 px-4'>
             <div className='d-flex justify-content-between'>
-              <div className='fs-5'>{translate('analytics.batches.batch-tracking')}</div>
+              <div className='fs-5'>{translate('analytics.batch-tracking')}</div>
               <div>
                 <span>Filters Go Here</span>
               </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's <project_name> repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Accidentally broken in https://github.com/BesLogic/releaf-canopeum/pull/259, added back _one, and _other since they have special meaning
