### PR TITLE
Fix DB initialization to use different site types examples

### DIFF
--- a/canopeum_backend/canopeum_backend/management/commands/initialize_database.py
+++ b/canopeum_backend/canopeum_backend/management/commands/initialize_database.py
@@ -423,17 +423,20 @@ class Command(BaseCommand):
             )
 
     def create_site_types(self):
-        site_type_names = (
-            ("Parks", "Parcs"),
-            ("Indigenous community", "Communauté Indigène"),
-            ("Educational Facility", "Établissement d'enseignement"),
-            ("Farms Land", "Terres agricoles"),
-            ("Corporate Lot", "Lot d'entreprise"),
-        )
+        # This mapping MUST MATCH pinMap in canopeum_frontend/src/pages/Map.tsx
+        site_type_names = {
+            1: ("Canopeum", "Canopeum"),
+            2: ("Parks", "Parcs"),
+            3: ("Indigenous community", "Communauté Indigène"),
+            4: ("Educational Facility", "Établissement d'enseignement"),
+            5: ("Farms Land", "Terres agricoles"),
+            6: ("Corporate Lot", "Lot d'entreprise"),
+        }
 
-        for name in site_type_names:
+        for site_type_id, name in site_type_names.items():
             Sitetype.objects.create(
-                name=Internationalization.objects.create(en=name[0], fr=name[1])
+                id=site_type_id,
+                name=Internationalization.objects.create(en=name[0], fr=name[1]),
             )
 
     def create_assets(self):
@@ -502,7 +505,7 @@ class Command(BaseCommand):
         site1 = Site.objects.create(
             name="Canopeum",
             is_public=True,
-            site_type=Sitetype.objects.get(name=Internationalization.objects.get(en="Parks")),
+            site_type=Sitetype.objects.get(id=1),
             coordinate=Coordinate.objects.create(
                 dms_latitude="45°30'06.1\"N",
                 dms_longitude="73°34'02.3\"W",
@@ -553,7 +556,7 @@ class Command(BaseCommand):
         site_2 = Site.objects.create(
             name="Maple Grove Retreat",
             is_public=True,
-            site_type=Sitetype.objects.get(name=Internationalization.objects.get(en="Parks")),
+            site_type=Sitetype.objects.get(id=2),
             coordinate=Coordinate.objects.create(
                 dms_latitude="46°48'33.6\"N",
                 dms_longitude="71°18'40.0\"W",
@@ -587,7 +590,7 @@ class Command(BaseCommand):
         site_3 = Site.objects.create(
             name="Lakeside Oasis",
             is_public=True,
-            site_type=Sitetype.objects.get(name=Internationalization.objects.get(en="Parks")),
+            site_type=Sitetype.objects.get(id=3),
             coordinate=Coordinate.objects.create(
                 dms_latitude="48°36'05.0\"N",
                 dms_longitude="71°18'27.0\"W",
@@ -622,7 +625,7 @@ class Command(BaseCommand):
         site_4 = Site.objects.create(
             name="Evergreen Trail",
             is_public=False,
-            site_type=Sitetype.objects.get(name=Internationalization.objects.get(en="Parks")),
+            site_type=Sitetype.objects.get(id=4),
             coordinate=Coordinate.objects.create(
                 dms_latitude="46°12'30.0\"N",
                 dms_longitude="74°35'30.0\"W",
@@ -654,7 +657,7 @@ class Command(BaseCommand):
         create_species_for_site(site_4, batches)
         create_posts_for_site(site_4)
 
-    def create_siteadmins(self):
+    def create_siteadmins(self) -> None:
         Siteadmin.objects.create(
             user=User.objects.get(email="tyrion@lannister.com"),
             site=Site.objects.get(name="Canopeum"),


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's <project_name> repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Relates to #269 . Not a full close because I noticed that a lot of other places in the site still default to just a `school` icon. The problem with those is that we would need a custom icon for canopeum, and https://www.npmjs.com/package/material-icons does not support custom icons.

Since we already use https://www.npmjs.com/package/@mui/material, we could consider https://www.npmjs.com/package/@mui/icons-material . Or to short-term just have Canopeum use the park icon

![image](https://github.com/user-attachments/assets/b8c2a738-1f3e-4ab8-b8f1-fb637b045f2a)

