### PR TITLE
Improve map cards responsiveness

### DIFF
--- a/canopeum_frontend/src/assets/styles/Navbar.scss
+++ b/canopeum_frontend/src/assets/styles/Navbar.scss
@@ -1,3 +1,10 @@
+.nav-underline {
+  .nav-link {
+    // underline on hover just looks weird if there's already an underline from nav
+    text-decoration: none;
+  }
+}
+
 .navbar {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 

--- a/canopeum_frontend/src/pages/Map.scss
+++ b/canopeum_frontend/src/pages/Map.scss
@@ -1,10 +1,5 @@
 @import '../App.scss';
 
-a,
-a:hover {
-  text-decoration: none !important;
-}
-
 #map-page-row-container {
   padding: 0 2rem;
 }
@@ -54,5 +49,6 @@ a:hover {
   .map-site-image {
     border-radius: $border-radius 0 0 $border-radius;
     width: unset;
+    object-fit: cover;
   }
 }

--- a/canopeum_frontend/src/pages/Map.tsx
+++ b/canopeum_frontend/src/pages/Map.tsx
@@ -112,12 +112,16 @@ const Map = () => {
         >
           <div className='py-3 d-flex flex-column gap-3'>
             {sites.map(site => (
-              <Link id={`${site.id}`} key={site.id} to={appRoutes.siteSocial(site.id)}>
-                <div
-                  className={`card ${
-                    selectedSiteId === site.id && 'border border-secondary border-5'
-                  }`}
-                  style={{ height: '150px' }}
+              <div
+                className={`card ${
+                  selectedSiteId === site.id && 'border border-secondary border-5'
+                }`}
+                key={site.id}
+              >
+                <Link
+                  className='stretched-link list-group-item-action'
+                  id={`${site.id}`}
+                  to={appRoutes.siteSocial(site.id)}
                 >
                   <div className='row g-0 h-100'>
                     <div className='col-lg-4'>
@@ -144,8 +148,8 @@ const Map = () => {
                       </div>
                     </div>
                   </div>
-                </div>
-              </Link>
+                </Link>
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's <project_name> repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Before: See https://github.com/BesLogic/releaf-canopeum/issues/275

This isn't a full fix for perfect responsiveness on mobile (so I'll keep the issue open). But this addresses the critical issues. There's still one specific zoom + window width combination where this happens (notice the images not completely covering and the double scrollbar)
![image](https://github.com/user-attachments/assets/130d888a-e8cc-4b91-a0ad-ce069345216f)


Fixes:
- leaked anchor CSS with !Important
- Reduced a layer of div inside anchor
- Fixed squished images
- Fixed completely broken Card display in mobile view

![image](https://github.com/user-attachments/assets/ed51dcad-2665-4c1a-81bd-5d58fa893748)
![image](https://github.com/user-attachments/assets/cb656a03-266f-4dc9-85ca-64e2d652aa78)
