### PR TITLE
Stop using `@import` in scss

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -22,6 +22,8 @@
     "dbaeumer.vscode-eslint",
     "dprint.dprint",
     "meganrogge.template-string-converter",
+    "mrmlnc.vscode-scss",
+    "sibiraj-s.vscode-scss-formatter", // This can likely eventually be replaced by dprint's malva plugin
     // Python/TOML
     "charliermarsh.ruff",
     "ms-python.mypy-type-checker",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -154,6 +154,9 @@
   "less.format.spaceAroundSelectorSeparator": true,
   "css.format.spaceAroundSelectorSeparator": true,
   "scss.format.spaceAroundSelectorSeparator": true,
+  "scssFormatter.printWidth": 100,
+  "scssFormatter.singleQuote": true,
+  "scssFormatter.trailingComma": "all",
 
   /*
   * Python

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -143,7 +143,7 @@
     "editor.defaultFormatter": "vscode.css-language-features"
   },
   "[scss]": {
-    "editor.defaultFormatter": "vscode.css-language-features"
+    "editor.defaultFormatter": "sibiraj-s.vscode-scss-formatter"
   },
   "[postcss]": {
     "editor.defaultFormatter": "vscode.css-language-features"

--- a/canopeum_frontend/src/App.scss
+++ b/canopeum_frontend/src/App.scss
@@ -1,30 +1,25 @@
-@import "../node_modules/bootstrap/scss/functions";
+// Load rsuite CSS first because we don't want it to have priority over bootstrap
+// We can also later override its css vars
+// TODO: Strongly consider to stop using rsuite, we have too many co-existing design systems !
+// (rsuite + mui + bootstrap)
+@use "../node_modules/rsuite/dist/rsuite.min.css";
 
-$primary: #007E51;
-$secondary: #F18200;
-$border-radius: 0.5rem;
-$link-decoration: none;
-/* TODO: We should reference palette, not direct colors
-https://github.com/BesLogic/releaf-canopeum/issues/249 */
-$green: #06C270;
-$lightgreen: #E8F3E9;
-$cream: #FFFAF5;
+// Load variables before Bootsrap so it generates the right theme colors
+@forward "./assets/styles/Variables.scss";
+@use "./assets/styles/Variables.scss" as *;
 
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Lato', Roboto, 'Helvetica Neue', Arial, sans-serif;
-$font-family-monospace: 'Helvetica Neue', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-$font-family-base: $font-family-sans-serif;
-$headings-font-family: Lato;
+@use "../node_modules/bootstrap/scss/bootstrap" with (
+  $font-family-sans-serif: $font-family-sans-serif,
+  $font-family-monospace: $font-family-monospace,
+  $font-family-base: $font-family-base,
+  $headings-font-family: $headings-font-family,
+  $headings-font-weight: $headings-font-weight,
+  $border-radius: $border-radius,
+  $link-decoration: $link-decoration,
+  $primary: $primary,
+  $secondary: $secondary,
+  $success: $success,
+  $white: $white
+);
 
-$headings-font-weight: 700;
-
-
-@import "rsuite/dist/rsuite.min.css";
-
-@import "../node_modules/bootstrap/scss/variables";
-@import "../node_modules/bootstrap/scss/mixins";
-
-@import "../node_modules/bootstrap/scss/bootstrap.scss";
-
-@import "./assets/styles/GlobalStyles.scss";
-
-$navbar-dark-toggler-border-color: rgba($white, 1);
+@use "./assets/styles/GlobalStyles.scss";

--- a/canopeum_frontend/src/App.scss
+++ b/canopeum_frontend/src/App.scss
@@ -2,13 +2,13 @@
 // We can also later override its css vars
 // TODO: Strongly consider to stop using rsuite, we have too many co-existing design systems !
 // (rsuite + mui + bootstrap)
-@use "../node_modules/rsuite/dist/rsuite.min.css";
+@use '../node_modules/rsuite/dist/rsuite.min.css';
 
 // Load variables before Bootsrap so it generates the right theme colors
-@forward "./assets/styles/Variables.scss";
-@use "./assets/styles/Variables.scss" as *;
+@forward './assets/styles/Variables.scss';
+@use './assets/styles/Variables.scss' as *;
 
-@use "../node_modules/bootstrap/scss/bootstrap" with (
+@use '../node_modules/bootstrap/scss/bootstrap' with (
   $font-family-sans-serif: $font-family-sans-serif,
   $font-family-monospace: $font-family-monospace,
   $font-family-base: $font-family-base,
@@ -22,4 +22,4 @@
   $white: $white
 );
 
-@use "./assets/styles/GlobalStyles.scss";
+@use './assets/styles/GlobalStyles.scss';

--- a/canopeum_frontend/src/assets/styles/DropdownMenu.scss
+++ b/canopeum_frontend/src/assets/styles/DropdownMenu.scss
@@ -1,3 +1,5 @@
+@use "../../assets/styles/Variables.scss" as *;
+
 .rs-dropdown-item-submenu:hover > .rs-dropdown-item-toggle {
   background-color: $lightgreen;
   color: inherit;

--- a/canopeum_frontend/src/assets/styles/DropdownMenu.scss
+++ b/canopeum_frontend/src/assets/styles/DropdownMenu.scss
@@ -1,4 +1,4 @@
-@use "../../assets/styles/Variables.scss" as *;
+@use '../../assets/styles/Variables.scss' as *;
 
 .rs-dropdown-item-submenu:hover > .rs-dropdown-item-toggle {
   background-color: $lightgreen;

--- a/canopeum_frontend/src/assets/styles/Forms.scss
+++ b/canopeum_frontend/src/assets/styles/Forms.scss
@@ -1,4 +1,4 @@
-@use "../../../node_modules/bootstrap/scss/bootstrap" as *;
+@use '../../../node_modules/bootstrap/scss/bootstrap' as *;
 
 $default-text-color: #433a2e;
 

--- a/canopeum_frontend/src/assets/styles/Forms.scss
+++ b/canopeum_frontend/src/assets/styles/Forms.scss
@@ -1,6 +1,6 @@
-@import "../node_modules/bootstrap/scss/variables";
+@use "../../../node_modules/bootstrap/scss/bootstrap" as *;
 
-$default-text-color: #433A2E;
+$default-text-color: #433a2e;
 
 .form-control::placeholder {
   color: map-get($theme-colors, light-gray);

--- a/canopeum_frontend/src/assets/styles/GlobalStyles.scss
+++ b/canopeum_frontend/src/assets/styles/GlobalStyles.scss
@@ -1,17 +1,13 @@
-// Import here all global style modules from this same folder
+@use "Variables.scss" as *;
 
-@import "./Buttons.scss";
-@import "./Forms.scss";
-@import "./Icons.scss";
-@import "./Navbar.scss";
-@import "./Transitions.scss";
-@import "./DropdownMenu.scss";
+// TODO (Sam. T): Move this file to a GlobalStyles/_index.scss and imported files into same folder
 
-$small-width: 540px;
-$medium-width: 720px;
-$large-width: 960px;
-$xlarge-width: 1200px;
-$xxlarge-width: 1600px;
+@use "Buttons.scss";
+@use "Forms.scss";
+@use "Icons.scss";
+@use "Navbar.scss";
+@use "Transitions.scss";
+@use "DropdownMenu.scss";
 
 ::-webkit-scrollbar {
   width: 10px;
@@ -28,11 +24,11 @@ $xxlarge-width: 1600px;
 }
 
 body {
-  background-image: url('@assets/images/TreeBackground.png');
+  background-image: url("@assets/images/TreeBackground.png");
 }
 
 .login-background {
-  background-image: url('@assets/images/LoginBackground.png');
+  background-image: url("@assets/images/LoginBackground.png");
   background-position: top;
   background-size: cover;
   background-repeat: no-repeat;

--- a/canopeum_frontend/src/assets/styles/GlobalStyles.scss
+++ b/canopeum_frontend/src/assets/styles/GlobalStyles.scss
@@ -1,13 +1,13 @@
-@use "Variables.scss" as *;
+@use 'Variables.scss' as *;
 
 // TODO (Sam. T): Move this file to a GlobalStyles/_index.scss and imported files into same folder
 
-@use "Buttons.scss";
-@use "Forms.scss";
-@use "Icons.scss";
-@use "Navbar.scss";
-@use "Transitions.scss";
-@use "DropdownMenu.scss";
+@use 'Buttons.scss';
+@use 'Forms.scss';
+@use 'Icons.scss';
+@use 'Navbar.scss';
+@use 'Transitions.scss';
+@use 'DropdownMenu.scss';
 
 ::-webkit-scrollbar {
   width: 10px;
@@ -24,11 +24,11 @@
 }
 
 body {
-  background-image: url("@assets/images/TreeBackground.png");
+  background-image: url('@assets/images/TreeBackground.png');
 }
 
 .login-background {
-  background-image: url("@assets/images/LoginBackground.png");
+  background-image: url('@assets/images/LoginBackground.png');
   background-position: top;
   background-size: cover;
   background-repeat: no-repeat;

--- a/canopeum_frontend/src/assets/styles/Variables.scss
+++ b/canopeum_frontend/src/assets/styles/Variables.scss
@@ -1,0 +1,38 @@
+/*
+* Bootstrap variables
+*/
+
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Lato', Roboto, 'Helvetica Neue', Arial, sans-serif;
+$font-family-monospace: 'Helvetica Neue', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+$font-family-base: $font-family-sans-serif;
+$headings-font-family: Lato;
+$headings-font-weight: 700;
+
+$border-radius: 0.5rem;
+$link-decoration: none;
+
+$primary: #007E51;
+$secondary: #F18200;
+$success: #06C270;
+
+
+$white: #FFFAF5;
+/* TODO: We should reference palette, not direct colors
+https://github.com/BesLogic/releaf-canopeum/issues/249 */
+$cream: #FFFAF5;
+
+/*
+* Custom variables
+*/
+
+// TODO (Sam T.): We should try to configure and properly use Bootstrap breakpoints instead
+$small-width: 540px;
+$medium-width: 720px;
+$large-width: 960px;
+$xlarge-width: 1200px;
+$xxlarge-width: 1600px;
+
+// TODO (Sam T.): We should configure bootstrap so that
+// our primary-derived color this represents uses the right shade of green.
+// Then use the generated bootstrap scss variable instead of $lightgreen
+$lightgreen: #E8F3E9;

--- a/canopeum_frontend/src/assets/styles/Variables.scss
+++ b/canopeum_frontend/src/assets/styles/Variables.scss
@@ -2,8 +2,23 @@
 * Bootstrap variables
 */
 
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Lato', Roboto, 'Helvetica Neue', Arial, sans-serif;
-$font-family-monospace: 'Helvetica Neue', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+$font-family-sans-serif: (
+  -apple-system,
+  BlinkMacSystemFont,
+  'Lato',
+  Roboto,
+  'Helvetica Neue',
+  Arial,
+  sans-serif
+);
+$font-family-monospace: (
+  'Helvetica Neue',
+  Monaco,
+  Consolas,
+  'Liberation Mono',
+  'Courier New',
+  monospace
+);
 $font-family-base: $font-family-sans-serif;
 $headings-font-family: Lato;
 $headings-font-weight: 700;
@@ -11,15 +26,14 @@ $headings-font-weight: 700;
 $border-radius: 0.5rem;
 $link-decoration: none;
 
-$primary: #007E51;
-$secondary: #F18200;
-$success: #06C270;
+$primary: #007e51;
+$secondary: #f18200;
+$success: #06c270;
 
-
-$white: #FFFAF5;
+$white: #fffaf5;
 /* TODO: We should reference palette, not direct colors
 https://github.com/BesLogic/releaf-canopeum/issues/249 */
-$cream: #FFFAF5;
+$cream: #fffaf5;
 
 /*
 * Custom variables
@@ -35,4 +49,4 @@ $xxlarge-width: 1600px;
 // TODO (Sam T.): We should configure bootstrap so that
 // our primary-derived color this represents uses the right shade of green.
 // Then use the generated bootstrap scss variable instead of $lightgreen
-$lightgreen: #E8F3E9;
+$lightgreen: #e8f3e9;

--- a/canopeum_frontend/src/assets/styles/export.module.scss
+++ b/canopeum_frontend/src/assets/styles/export.module.scss
@@ -1,7 +1,7 @@
-@import '../../App.scss';
+@use "Variables.scss" as *;
 
 :export {
   primary: $primary;
   secondary: $secondary;
-  success: map-get($theme-colors, success);
+  success: $success;
 }

--- a/canopeum_frontend/src/assets/styles/export.module.scss
+++ b/canopeum_frontend/src/assets/styles/export.module.scss
@@ -1,4 +1,4 @@
-@use "Variables.scss" as *;
+@use 'Variables.scss' as *;
 
 :export {
   primary: $primary;

--- a/canopeum_frontend/src/components/analytics/AnalyticsSiteHeader.scss
+++ b/canopeum_frontend/src/components/analytics/AnalyticsSiteHeader.scss
@@ -1,4 +1,4 @@
-@import '../../App.scss';
+@use "../../assets/styles/Variables.scss" as *;
 
 .header-card {
   display: flex;

--- a/canopeum_frontend/src/components/analytics/AnalyticsSiteHeader.scss
+++ b/canopeum_frontend/src/components/analytics/AnalyticsSiteHeader.scss
@@ -1,4 +1,4 @@
-@use "../../assets/styles/Variables.scss" as *;
+@use '../../assets/styles/Variables.scss' as *;
 
 .header-card {
   display: flex;

--- a/canopeum_frontend/src/components/analytics/ImageUpload.scss
+++ b/canopeum_frontend/src/components/analytics/ImageUpload.scss
@@ -1,4 +1,4 @@
-@import '../../App.scss';
+@use "../../assets/styles/Variables.scss" as *;
 
 .upload-button {
   background-color: var(--bs-body-bg);

--- a/canopeum_frontend/src/components/analytics/ImageUpload.scss
+++ b/canopeum_frontend/src/components/analytics/ImageUpload.scss
@@ -1,4 +1,4 @@
-@use "../../assets/styles/Variables.scss" as *;
+@use '../../assets/styles/Variables.scss' as *;
 
 .upload-button {
   background-color: var(--bs-body-bg);

--- a/canopeum_frontend/src/components/analytics/SiteAdminTabs.scss
+++ b/canopeum_frontend/src/components/analytics/SiteAdminTabs.scss
@@ -1,4 +1,4 @@
-@import '../../App.scss';
+@use "../../assets/styles/Variables.scss" as *;
 
 .admin-site-tabs.nav .nav-link {
   color: $cream;

--- a/canopeum_frontend/src/components/analytics/SiteAdminTabs.scss
+++ b/canopeum_frontend/src/components/analytics/SiteAdminTabs.scss
@@ -1,4 +1,4 @@
-@use "../../assets/styles/Variables.scss" as *;
+@use '../../assets/styles/Variables.scss' as *;
 
 .admin-site-tabs.nav .nav-link {
   color: $cream;

--- a/canopeum_frontend/src/components/settings/SettingsTab.module.scss
+++ b/canopeum_frontend/src/components/settings/SettingsTab.module.scss
@@ -1,4 +1,4 @@
-@import '../../App.scss';
+@use '../../assets/styles/Variables.scss' as *;
 
 .settingsTab {
   border: none;
@@ -7,6 +7,6 @@
 }
 
 .selectedSettingsTab {
-  border-left: 6px solid map-get($theme-colors, primary);
+  border-left: 6px solid $primary;
   background: $lightgreen;
 }

--- a/canopeum_frontend/src/components/social/SiteSocialHeader.scss
+++ b/canopeum_frontend/src/components/social/SiteSocialHeader.scss
@@ -1,4 +1,4 @@
-@import '../../App.scss';
+@use '../../assets/styles/Variables.scss' as *;
 
 .site-social-header-card {
   display: flex;

--- a/canopeum_frontend/src/pages/Map.scss
+++ b/canopeum_frontend/src/pages/Map.scss
@@ -1,4 +1,4 @@
-@import '../App.scss';
+@use '../assets/styles/Variables.scss' as *;
 
 a,
 a:hover {

--- a/canopeum_frontend/src/pages/UserManagement.scss
+++ b/canopeum_frontend/src/pages/UserManagement.scss
@@ -1,4 +1,4 @@
-@import '../App.scss';
+@use '../assets/styles/Variables.scss' as *;
 
 .settings-left-nav-menu {
   margin-bottom: 2rem;


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's <project_name> repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Closes #281

This is a very important fix performance-wise:
- Downloads a lot less
- Debugging CSS is a lot easier now that styles aren't set 7 times each
- Vite's "Fast refresh" stops being unresponsive for a while
- Probably fixes my Edge dev tool crashes (at least haven't had one in a while and it feels more responsive)
