### PR TITLE
Improvements around justify-content-between usages

### DIFF
--- a/canopeum_frontend/src/components/CreatePostWidget.tsx
+++ b/canopeum_frontend/src/components/CreatePostWidget.tsx
@@ -122,7 +122,7 @@ const CreatePostWidget = ({ siteId, addNewPost }: Props) => {
 
   return (
     <div className='card'>
-      <div className='card-body rounded-2 d-flex flex-column gap-2'>
+      <div className='card-body d-flex flex-column gap-2'>
         <div className='d-flex justify-content-between'>
           <h2>New Post</h2>
 

--- a/canopeum_frontend/src/components/IconBadge.tsx
+++ b/canopeum_frontend/src/components/IconBadge.tsx
@@ -15,7 +15,7 @@ const IconBadge = (props: Props) => {
   return (
     <div
       className={`${bgColor} text-center rounded-circle`}
-      style={{ height: '2em', width: '2em' }}
+      style={{ height: '2em', width: '2em', minWidth: '2em' }}
     >
       <span
         className='material-symbols-outlined text-light align-middle'

--- a/canopeum_frontend/src/components/analytics/BatchTable.tsx
+++ b/canopeum_frontend/src/components/analytics/BatchTable.tsx
@@ -66,7 +66,7 @@ const BatchTable = (props: Props) => {
                 scope='col'
                 style={{ width: '17.5rem' }}
               >
-                <div className='d-flex justify-content-between align-items-center card-title'>
+                <div className='d-flex justify-content-between align-items-center'>
                   {batch.name}
 
                   <BatchActions

--- a/canopeum_frontend/src/components/analytics/OptionQuantitySelector.tsx
+++ b/canopeum_frontend/src/components/analytics/OptionQuantitySelector.tsx
@@ -135,7 +135,7 @@ const OptionQuantitySelector = <TValue extends OptionQuantityValueType>(
       <ul className='list-group list-group-flush overflow-hidden mt-1'>
         {selected.map((optionQuantity, index) => (
           <li
-            className='list-group-item row d-flex justify-content-between'
+            className='list-group-item row d-flex align-items-center justify-content-between'
             key={`selected-specie-${optionQuantity.option.value}`}
           >
             <div className='col-6'>{optionQuantity.option.displayText}</div>

--- a/canopeum_frontend/src/components/analytics/SiteSummaryCard.tsx
+++ b/canopeum_frontend/src/components/analytics/SiteSummaryCard.tsx
@@ -31,14 +31,17 @@ const SiteSummaryCard = ({ site, admins, onSiteChange, onSiteEdit }: Props) => {
       className='col-12 col-md-6 col-xl-4 col-xxl-3'
       key={site.name}
     >
-      <div className='card h-100 w-100 py-3'>
+      <div className='card h-100 w-100'>
         <div className='card-body d-flex flex-column h-100'>
           <div className='d-flex justify-content-between align-items-center card-title'>
-            <Link className='nav-link flex-grow-1 me-3' to={appRoutes.site(site.id)}>
-              <div className='d-flex gap-1 align-items-center flex-grow-1'>
-                <IconBadge iconKey={getSiteTypeIconKey(site.siteType.id)} />
-                <h5 className='mb-0 text-ellipsis'>{site.name}</h5>
-              </div>
+            <Link
+              className='nav-link me-2 d-flex gap-1 align-items-center'
+              // idk why just 100% still goes over the card length, so adjust for icon size ?
+              style={{ width: 'calc(100% - 2em)' }}
+              to={appRoutes.site(site.id)}
+            >
+              <IconBadge iconKey={getSiteTypeIconKey(site.siteType.id)} />
+              <h5 className='mb-0 text-ellipsis'>{site.name}</h5>
             </Link>
 
             {currentUser?.role === 'MegaAdmin'

--- a/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
+++ b/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
@@ -215,10 +215,10 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
               {t('analytics.site-modal.site-research-partner')}
             </label>
             <div
-              className='d-flex gap-1 align-items-center text-center justify-content-evenly'
+              className='d-flex'
               id='site-research-partner'
             >
-              <div className='form-check form-check-inline'>
+              <div className='col form-check form-check-inline'>
                 <input
                   checked={!!site.researchPartner}
                   className='form-check-input'
@@ -233,7 +233,7 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
                 </label>
               </div>
 
-              <div className='form-check form-check-inline'>
+              <div className='col form-check form-check-inline'>
                 <input
                   checked={!site.researchPartner}
                   className='form-check-input'
@@ -247,6 +247,8 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
                   {t('analytics.site-modal.no')}
                 </label>
               </div>
+
+              <div className='col' /> {/* spacer */}
             </div>
           </div>
 
@@ -255,10 +257,10 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
               {t('analytics.site-modal.site-map-visibility')}
             </label>
             <div
-              className='d-flex gap-1 align-items-center text-center justify-content-evenly'
+              className='d-flex'
               id='site-map-visibility'
             >
-              <div className='form-check form-check-inline'>
+              <div className='col form-check form-check-inline'>
                 <input
                   checked={!!site.visibleOnMap}
                   className='form-check-input'
@@ -273,7 +275,7 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
                 </label>
               </div>
 
-              <div className='form-check form-check-inline'>
+              <div className='col form-check form-check-inline'>
                 <input
                   checked={!site.visibleOnMap}
                   className='form-check-input'
@@ -287,6 +289,8 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
                   {t('analytics.site-modal.invisible')}
                 </label>
               </div>
+
+              <div className='col' /> {/* spacer */}
             </div>
           </div>
         </form>

--- a/canopeum_frontend/src/components/settings/AdminCard.tsx
+++ b/canopeum_frontend/src/components/settings/AdminCard.tsx
@@ -5,7 +5,7 @@ type Props = {
 }
 
 const AdminCard = ({ admin }: Props) => (
-  <div className='card h-100 py-2'>
+  <div className='card h-100'>
     <div className='card-body'>
       <h5 className='card-title d-flex align-items-center'>
         <span className='material-symbols-outlined fill-icon icon-lg'>person</span>

--- a/canopeum_frontend/src/components/settings/EditProfile.tsx
+++ b/canopeum_frontend/src/components/settings/EditProfile.tsx
@@ -217,12 +217,10 @@ const EditProfile = () => {
           col-12
           col-lg-8
           col-xl-6
-          m-0
           d-flex
           flex-column
           justify-content-between
-          py-3
-          gap-2
+          py-2
         '>
           <form className='form'>
             <div className='mb-4'>
@@ -268,7 +266,7 @@ const EditProfile = () => {
             </div>
 
             <button
-              className='btn btn-primary'
+              className='btn btn-primary mb-4'
               onClick={() => setDoChangePassword(previous => !previous)}
               type='button'
             >
@@ -279,7 +277,7 @@ const EditProfile = () => {
 
             {doChangePassword && (
               <>
-                <div className='mb-4 mt-4'>
+                <div className='mb-4'>
                   <label htmlFor='password-input'>
                     {translate('settings.edit-profile.current-password')}
                   </label>
@@ -368,9 +366,9 @@ const EditProfile = () => {
             )}
           </form>
 
-          <div className='form-actions d-flex justify-content-between align-items-center gap-5'>
+          <div className='d-flex justify-content-between'>
             <button
-              className='btn btn-outline-primary flex-grow-1'
+              className='btn btn-outline-primary'
               disabled={!changesToSave}
               onClick={handleCancel}
               type='button'
@@ -378,7 +376,7 @@ const EditProfile = () => {
               {translate('generic.cancel')}
             </button>
             <button
-              className='btn btn-primary flex-grow-1'
+              className='btn btn-primary'
               disabled={!changesToSave}
               onClick={handleSaveProfile}
               type='button'

--- a/canopeum_frontend/src/components/settings/TermsAndPolicies.tsx
+++ b/canopeum_frontend/src/components/settings/TermsAndPolicies.tsx
@@ -6,7 +6,7 @@ const TermsAndPolicies = () => {
   return (
     <div className='d-flex flex-column h-100'>
       <h2 className='text-light'>{translate('settings.terms-and-policies.title')}</h2>
-      <div className='bg-white rounded-2 mt-4 px-4 py-3 flex-grow-1 row m-0 justify-content-center'>
+      <div className='card mt-4 px-4 py-3 flex-grow-1'>
         <p>
           Lorem, ipsum dolor sit amet consectetur adipisicing elit. Autem, rem architecto?
           Reiciendis iusto debitis aspernatur sit. Quisquam, nihil quaerat natus cupiditate ea

--- a/canopeum_frontend/src/components/social/AnnouncementCard.tsx
+++ b/canopeum_frontend/src/components/social/AnnouncementCard.tsx
@@ -16,7 +16,7 @@ const AnnouncementCard = ({ announcement, viewMode, onEdit }: Props) => {
 
   return (
     <>
-      <div className='card rounded'>
+      <div className='card'>
         <div className='card-body'>
           <div className='d-flex justify-content-between align-items-center pb-3'>
             <h2 className='card-title'>Announcement</h2>

--- a/canopeum_frontend/src/components/social/ContactCard.tsx
+++ b/canopeum_frontend/src/components/social/ContactCard.tsx
@@ -19,7 +19,7 @@ const ContactCard = ({ contact, viewMode, onEdit }: Props) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
   const renderContactCard = () => (
-    <div className='card rounded'>
+    <div className='card'>
       <div className='card-body'>
         <div className='d-flex justify-content-between align-items-center pb-3'>
           <h2 className='card-title'>Contact</h2>

--- a/canopeum_frontend/src/components/social/PostCard.tsx
+++ b/canopeum_frontend/src/components/social/PostCard.tsx
@@ -83,7 +83,7 @@ const PostCard = ({ post, deletePost }: Props) => {
 
   return (
     <div className='card'>
-      <div className='card-body rounded-2 d-flex flex-column gap-3'>
+      <div className='card-body d-flex flex-column gap-3'>
         <div className='d-flex justify-content-start align-items-center gap-2'>
           <img
             alt='site'

--- a/canopeum_frontend/src/pages/Home.tsx
+++ b/canopeum_frontend/src/pages/Home.tsx
@@ -33,7 +33,7 @@ const Home = () => {
   const renderPosts = () => {
     if (loadingError) {
       return (
-        <div className='bg-white rounded-2 px-5 py-4 d-flex flex-column gap-3'>
+        <div className='card px-5 py-4 d-flex flex-column gap-3'>
           <span>{loadingError}</span>
         </div>
       )

--- a/canopeum_frontend/src/pages/SiteSocialPage.tsx
+++ b/canopeum_frontend/src/pages/SiteSocialPage.tsx
@@ -182,7 +182,7 @@ const SiteSocialPage = () => {
           </div>
 
           <div className='col-12 col-md-6 col-lg-7 col-xl-8'>
-            <div className='rounded-2 d-flex flex-column gap-4'>
+            <div className='d-flex flex-column gap-4'>
               {viewMode === 'admin' && <CreatePostWidget addNewPost={addNewPost} siteId={siteId} />}
               <div className='d-flex flex-column gap-4'>
                 {isLoadingFirstPage


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's <project_name> repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

The other half of https://github.com/BesLogic/releaf-canopeum/pull/299

The only visual change should be this:

Before:
![image](https://github.com/user-attachments/assets/8857e215-3213-4570-936c-e2feb06b9739)
![image](https://github.com/user-attachments/assets/a263c017-b445-4dc7-b6fb-05d790c5270d)

After:
![image](https://github.com/user-attachments/assets/681b2c23-89d2-45ef-9423-6357fe26e9c8)
![image](https://github.com/user-attachments/assets/c14bb0d7-c8cd-4bbe-bb51-623d3577660a)

