### PR TITLE
Automatic language detection and save

### DIFF
--- a/canopeum_frontend/package-lock.json
+++ b/canopeum_frontend/package-lock.json
@@ -16,6 +16,7 @@
         "bootstrap": "^5.3.3",
         "browser-image-compression": "^2.0.2",
         "i18next": "^23.10.1",
+        "i18next-browser-languagedetector": "^8.0.0",
         "i18next-http-backend": "^2.5.0",
         "jwt-decode": "4.0.0",
         "maplibre-gl": "^4.1.1",
@@ -10388,6 +10389,15 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.0.tgz",
+      "integrity": "sha512-zhXdJXTTCoG39QsrOCiOabnWj2jecouOqbchu3EfhtSHxIB5Uugnm9JaizenOy39h7ne3+fLikIjeW88+rgszw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"

--- a/canopeum_frontend/package.json
+++ b/canopeum_frontend/package.json
@@ -23,6 +23,7 @@
     "bootstrap": "^5.3.3",
     "browser-image-compression": "^2.0.2",
     "i18next": "^23.10.1",
+    "i18next-browser-languagedetector": "^8.0.0",
     "i18next-http-backend": "^2.5.0",
     "jwt-decode": "4.0.0",
     "maplibre-gl": "^4.1.1",

--- a/canopeum_frontend/src/i18n.ts
+++ b/canopeum_frontend/src/i18n.ts
@@ -1,9 +1,14 @@
 import { default as i18n } from 'i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
 
 import resources from './locale'
 
-void i18n.use(initReactI18next).init({
-  resources,
-  lng: 'en',
-})
+void i18n
+  .use(initReactI18next)
+  .use(LanguageDetector)
+  .init({
+    supportedLngs: Object.keys(resources),
+    resources,
+    detection: { convertDetectedLanguage: lng => lng.split('-')[0] }, // fr-CA -> fr
+  })


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's Releaf / Canopeum repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests locally (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Automatically detects the user's navigator preferred language. And save the last selection in localStorage
