### PR TITLE
clearer widget deletion + post edit button

### DIFF
--- a/canopeum_frontend/src/components/social/PostCard.tsx
+++ b/canopeum_frontend/src/components/social/PostCard.tsx
@@ -1,4 +1,5 @@
 import { useContext, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Dropdown, Popover } from 'rsuite'
 import DropdownMenu from 'rsuite/esm/Dropdown/DropdownMenu'
 import type { OverlayTriggerHandle } from 'rsuite/esm/internals/Picker'
@@ -23,6 +24,7 @@ type Props = {
 }
 
 const PostCard = ({ post, deletePost }: Props) => {
+  const { t } = useTranslation()
   const { formatDate } = useContext(LanguageContext)
   const { toggleLike } = usePostsStore()
   const { getApiClient } = useApiClient()
@@ -72,10 +74,13 @@ const PostCard = ({ post, deletePost }: Props) => {
       style={{ width: 'fit-content' }}
     >
       <DropdownMenu>
-        <Dropdown.Item onClick={() => setConfirmPostDeleteOpen(true)}>
-          <div className='d-flex gap-2'>
-            <span className='material-symbols-outlined text-danger'>delete</span>
-          </div>
+        <Dropdown.Item>
+          <span className='material-symbols-outlined align-middle'>edit_square</span>{' '}
+          {t('generic.edit')} (Not yet implemented)
+        </Dropdown.Item>
+        <Dropdown.Item className='' onClick={() => setConfirmPostDeleteOpen(true)}>
+          <span className='material-symbols-outlined align-middle text-danger'>delete</span>
+          <span className='text-danger'>{' '}{t('generic.delete')}</span>
         </Dropdown.Item>
       </DropdownMenu>
     </Popover>

--- a/canopeum_frontend/src/components/social/WidgetDialog.tsx
+++ b/canopeum_frontend/src/components/social/WidgetDialog.tsx
@@ -50,7 +50,7 @@ const WidgetDialog = ({ handleClose, open }: Props) => {
                   onClick={() => handleClose('delete', innerWidget)}
                   type='button'
                 >
-                  <span className='material-symbols-outlined text-primary'>cancel</span>
+                  <span className='material-symbols-outlined text-danger'>delete</span>
                 </button>
               )}
             </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's Releaf / Canopeum repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests locally (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

![image](https://github.com/user-attachments/assets/ba9bc029-2ad6-47f0-a139-bdcaeb5110fd)
![image](https://github.com/user-attachments/assets/87622187-75bb-4e87-8835-2234e9afdc34)
