### PR TITLE
feat: adjust asset viewer styling

### DIFF
--- a/canopeum_frontend/src/components/assets/AssetViewer.scss
+++ b/canopeum_frontend/src/components/assets/AssetViewer.scss
@@ -1,15 +1,16 @@
 .asset-viewer-container {
   position: fixed !important;
-  top: 4rem;
+  top: 3.8rem;
   left: 0;
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(10px);
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: calc(100% - 4rem);
+  height: calc(100% - 3.8rem);
   padding: 3rem;
   z-index: 2;
 }
@@ -20,18 +21,19 @@
   width: 100%;
   height: 100%;
   align-content: center;
-  background-color: rgba(0, 0, 0, 0.75);
+  object-fit: cover;
+  overflow: hidden;
 }
 
 .carousel .btn-close {
   position: absolute;
   top: 1rem;
-  right: 1.5rem;
+  right: 8.5rem;
   z-index: 3;
 }
 
 .carousel-inner {
-  width: 80%;
+  width: 62.5%;
   height: 100%;
 }
 
@@ -39,4 +41,12 @@
   max-width: 100%;
   max-height: 100%;
   margin: auto;
+}
+
+.carousel-control-prev,
+.carousel-control-next {
+  position: relative;
+  height: 100%;
+  width: 3rem;
+  margin: 0 3rem;
 }

--- a/canopeum_frontend/src/components/assets/AssetViewer.tsx
+++ b/canopeum_frontend/src/components/assets/AssetViewer.tsx
@@ -26,12 +26,12 @@ const AssetViewer = ({ medias, handleClose, mediaSelectedIndex }: AssetViewerPro
         </button>
       )}
     <button
-        className='btn-close text-light shadow-none'
-        onClick={handleClose}
-        type='button'
-      >
-        <span className='material-symbols-outlined'>cancel</span>
-      </button>
+      className='btn-close text-light shadow-none'
+      onClick={handleClose}
+      type='button'
+    >
+      <span className='material-symbols-outlined'>cancel</span>
+    </button>
     <div className='carousel-inner'>
       {medias.map((media, index) => (
         <div

--- a/canopeum_frontend/src/components/assets/AssetViewer.tsx
+++ b/canopeum_frontend/src/components/assets/AssetViewer.tsx
@@ -13,14 +13,26 @@ const AssetViewer = ({ medias, handleClose, mediaSelectedIndex }: AssetViewerPro
     className='carousel carousel-fade asset-viewer-container'
     id='carouselFade'
   >
-    <div className='carousel-inner'>
-      <button
+    {medias.length > 1
+      && (
+        <button
+          className='carousel-control-prev'
+          data-bs-slide='prev'
+          data-bs-target='#carouselFade'
+          type='button'
+        >
+          <span aria-hidden='true' className='carousel-control-prev-icon' />
+          <span className='visually-hidden'>Previous</span>
+        </button>
+      )}
+    <button
         className='btn-close text-light shadow-none'
         onClick={handleClose}
         type='button'
       >
         <span className='material-symbols-outlined'>cancel</span>
       </button>
+    <div className='carousel-inner'>
       {medias.map((media, index) => (
         <div
           className={`carousel-item ${
@@ -34,18 +46,6 @@ const AssetViewer = ({ medias, handleClose, mediaSelectedIndex }: AssetViewerPro
         </div>
       ))}
     </div>
-    {medias.length > 1
-      && (
-        <button
-          className='carousel-control-prev'
-          data-bs-slide='prev'
-          data-bs-target='#carouselFade'
-          type='button'
-        >
-          <span aria-hidden='true' className='carousel-control-prev-icon' />
-          <span className='visually-hidden'>Previous</span>
-        </button>
-      )}
     {medias.length > 1
       && (
         <button


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's Releaf / Canopeum repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests locally (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Closes #280 

Adjusted asset viewer styling to match Figma as much as possible. 

Before:
![image](https://github.com/user-attachments/assets/a0813ef6-8b43-4561-9f50-e78f99e3e3b4)

After:
![image](https://github.com/user-attachments/assets/6dc3ce3c-3d74-4961-a145-76af0254b6ee)
