### PR TITLE
Applied review and simplifications for #335 

### DIFF
--- a/canopeum_frontend/.eslintrc.cjs
+++ b/canopeum_frontend/.eslintrc.cjs
@@ -25,6 +25,14 @@ module.exports = {
     'src/services/api.ts',
   ],
   rules: {
+    '@typescript-eslint/no-floating-promises': ['error', {
+      // Don't even ignore voided promises. Force a comment explaining.
+      ignoreVoid: false, // TODO: This could be added to Beslogic's extra-strict preset
+      allowForKnownSafeCalls: [ // TODO: This could be added to Beslogic's presets
+        // Doesn't throw and already console.warn itself
+        { from: 'package', package: 'i18next', name: 'changeLanguage' },
+      ],
+    }],
     'react-refresh/only-export-components': [
       'warn',
       { allowConstantExport: true }, // Works fine in Vite

--- a/canopeum_frontend/index.html
+++ b/canopeum_frontend/index.html
@@ -1,38 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <link
       rel="icon"
       type="image/svg+xml"
       href="/favicon.ico"
-    />
+    >
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0"
-    />
+    >
     <title>Releaf</title>
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
-    />
+    >
     <link
       href="https://unpkg.com/maplibre-gl@4.1.1/dist/maplibre-gl.css"
       rel="stylesheet"
-    />
+    >
     <link
       rel="preconnect"
       href="https://fonts.googleapis.com"
-    />
+    >
     <link
       rel="preconnect"
       href="https://fonts.gstatic.com"
       crossorigin
-    />
+    >
     <link
       href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
       rel="stylesheet"
-    />
+    >
   </head>
 
   <body>

--- a/canopeum_frontend/src/components/MainLayout.tsx
+++ b/canopeum_frontend/src/components/MainLayout.tsx
@@ -1,12 +1,10 @@
 import { useContext, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
 import { Navigate, Outlet, Route, Routes } from 'react-router-dom'
 
 import { AuthenticationContext } from './context/AuthenticationContext'
 import Navbar from './Navbar'
 import TermsAndPolicies from '@components/settings/TermsAndPolicies'
 import { appRoutes } from '@constants/routes.constant'
-import useErrorHandling from '@hooks/ErrorHandlingHook'
 import Analytics from '@pages/Analytics'
 import AnalyticsSite from '@pages/AnalyticsSite'
 import Home from '@pages/Home'
@@ -55,21 +53,9 @@ const AuthenticatedRoutes = () => {
 
 const MainLayout = () => {
   const { initAuth } = useContext(AuthenticationContext)
-  const { t: translate } = useTranslation()
-  const { getErrorMessage } = useErrorHandling()
 
   // Try authenticating user on app start if token was saved in storage
-  useEffect(() => {
-    const runInitAuth = async () => initAuth()
-
-    runInitAuth().catch((error: unknown) => {
-      const errorMessage = getErrorMessage(
-        error,
-        translate('auth.user-token-not-found'),
-      )
-      console.error(errorMessage)
-    })
-  }, [])
+  useEffect(() => void initAuth(), [initAuth])
 
   return (
     <Routes>

--- a/canopeum_frontend/src/components/Navbar.tsx
+++ b/canopeum_frontend/src/components/Navbar.tsx
@@ -3,9 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router-dom'
 
 import { AuthenticationContext } from './context/AuthenticationContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import { appRoutes } from '@constants/routes.constant'
-import useErrorHandling from '@hooks/ErrorHandlingHook'
 import type { RoleEnum } from '@services/api'
 
 type NavbarItem = {
@@ -48,8 +46,6 @@ const Navbar = () => {
   const { i18n: { changeLanguage, language }, t: translate } = useTranslation()
   const [currentLanguage, setCurrentLanguage] = useState(language)
   const { currentUser } = useContext(AuthenticationContext)
-  const { getErrorMessage } = useErrorHandling()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
   const location = useLocation()
 
   const handleChangeLanguage = () => {
@@ -57,13 +53,7 @@ const Navbar = () => {
       ? 'fr'
       : 'en'
     setCurrentLanguage(newLanguage)
-    changeLanguage(newLanguage).catch((error: unknown) => {
-      const errorMessage = getErrorMessage(
-        error,
-        translate('errors.change-language-failed'),
-      )
-      openAlertSnackbar(errorMessage, { severity: 'error' })
-    })
+    changeLanguage(newLanguage)
   }
 
   const { isAuthenticated, showLogoutModal } = useContext(AuthenticationContext)

--- a/canopeum_frontend/src/components/analytics/BatchActions.tsx
+++ b/canopeum_frontend/src/components/analytics/BatchActions.tsx
@@ -20,7 +20,7 @@ const BatchActions = ({ onEdit, onDelete, batchDetail }: Props) => {
   const { t: translate } = useTranslation()
   const { openAlertSnackbar } = useContext(SnackbarContext)
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const whisperRef = useRef<OverlayTriggerHandle>(null)
 
@@ -40,14 +40,11 @@ const BatchActions = ({ onEdit, onDelete, batchDetail }: Props) => {
   const handleConfirmDeleteClose = (proceed: boolean) => {
     setConfirmDeleteOpen(false)
     if (proceed) {
-      deleteBatch().catch((error: unknown) =>
-        openAlertSnackbar(
-          getErrorMessage(
-            error,
-            translate('analyticsSite.delete-batch.error', { batchName: batchDetail.name }),
-          ),
-          { severity: 'error' },
-        )
+      deleteBatch().catch(
+        displayUnhandledAPIError(
+          'analyticsSite.delete-batch.error',
+          { batchName: batchDetail.name },
+        ),
       )
     }
   }

--- a/canopeum_frontend/src/components/analytics/BatchTable.tsx
+++ b/canopeum_frontend/src/components/analytics/BatchTable.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import BatchActions from '@components/analytics/BatchActions'
 import BatchSponsorLogo from '@components/batches/BatchSponsorLogo'
 import { LanguageContext } from '@components/context/LanguageContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import useErrorHandling from '@hooks/ErrorHandlingHook'
 import type { BatchDetail } from '@services/api'
@@ -24,8 +23,7 @@ const BatchTable = (props: Props) => {
   const { t } = useTranslation()
   const { translateValue } = useContext(LanguageContext)
   const { getApiClient } = useApiClient()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [batches, setBatches] = useState(props.batches)
 
@@ -76,14 +74,11 @@ const BatchTable = (props: Props) => {
                     batchDetail={batch}
                     onDelete={() => setBatches(previous => previous.filter(b => b.id !== batch.id))}
                     onEdit={() =>
-                      fetchBatch(props.siteId).catch((error: unknown) =>
-                        openAlertSnackbar(
-                          getErrorMessage(
-                            error,
-                            t('errors.fetch-batch-failed', { batchName: batch.name }),
-                          ),
-                          { severity: 'error' },
-                        )
+                      fetchBatch(props.siteId).catch(
+                        displayUnhandledAPIError(
+                          'errors.fetch-batch-failed',
+                          { batchName: batch.name },
+                        ),
                       )}
                   />
                 </div>

--- a/canopeum_frontend/src/components/analytics/FertilizersSelector.tsx
+++ b/canopeum_frontend/src/components/analytics/FertilizersSelector.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import OptionQuantitySelector, { type SelectorOption, type SelectorOptionQuantity } from '@components/analytics/OptionQuantitySelector'
 import { LanguageContext } from '@components/context/LanguageContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import useErrorHandling from '@hooks/ErrorHandlingHook'
 import { FertilizerType } from '@services/api'
@@ -19,8 +18,7 @@ const FertilizersSelector = ({ onChange, fertilizers }: Props) => {
   const { t: translate } = useTranslation()
   const { translateValue } = useContext(LanguageContext)
   const { getApiClient } = useApiClient()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [availableFertilizers, setAvailableFertilizers] = useState<Map<number, FertilizerType>>(
     new Map(),
@@ -45,10 +43,8 @@ const FertilizersSelector = ({ onChange, fertilizers }: Props) => {
       setAvailableFertilizers(fertilizerMap)
       setOptions(fertilizerOptions)
     }
-    fetchFertilizers().catch((error: unknown) =>
-      openAlertSnackbar(getErrorMessage(error, translate('errors.fetch-fertilizers-failed')), {
-        severity: 'error',
-      })
+    fetchFertilizers().catch(
+      displayUnhandledAPIError('errors.fetch-fertilizers-failed'),
     )
   }, [])
 

--- a/canopeum_frontend/src/components/analytics/MulchLayersSelector.tsx
+++ b/canopeum_frontend/src/components/analytics/MulchLayersSelector.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import OptionQuantitySelector, { type SelectorOption, type SelectorOptionQuantity } from '@components/analytics/OptionQuantitySelector'
 import { LanguageContext } from '@components/context/LanguageContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import useErrorHandling from '@hooks/ErrorHandlingHook'
 import { MulchLayerType } from '@services/api'
@@ -19,8 +18,7 @@ const MulchLayersSelector = ({ onChange, mulchLayers }: Props) => {
   const { t: translate } = useTranslation()
   const { translateValue } = useContext(LanguageContext)
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [availableMulchLayers, setAvailableMulchLayers] = useState<Map<number, MulchLayerType>>(
     new Map(),
@@ -45,10 +43,8 @@ const MulchLayersSelector = ({ onChange, mulchLayers }: Props) => {
       setAvailableMulchLayers(mulchLayerMap)
       setOptions(mulchLayerOptions)
     }
-    fetchMulchLayers().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-mulch-layers-failed')),
-      )
+    fetchMulchLayers().catch(
+      displayUnhandledAPIError('errors.fetch-mulch-layers-failed'),
     )
   }, [])
 

--- a/canopeum_frontend/src/components/analytics/SiteSummaryActions.tsx
+++ b/canopeum_frontend/src/components/analytics/SiteSummaryActions.tsx
@@ -23,7 +23,7 @@ const SiteSummaryActions = ({ siteSummary, admins, onSiteChange, onSiteEdit }: P
   const { t: translate } = useTranslation()
   const { openAlertSnackbar } = useContext(SnackbarContext)
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
   const whisperRef = useRef<OverlayTriggerHandle>(null)
 
   const [filteredAdmins, setFilteredAdmins] = useState(admins)
@@ -113,11 +113,7 @@ const SiteSummaryActions = ({ siteSummary, admins, onSiteChange, onSiteEdit }: P
       return
     }
 
-    deleteSite().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.delete-site-failed')),
-      )
-    )
+    deleteSite().catch(displayUnhandledAPIError('errors.delete-site-failed'))
   }
 
   const administratorsSelection = (

--- a/canopeum_frontend/src/components/analytics/SupportSpeciesSelector.tsx
+++ b/canopeum_frontend/src/components/analytics/SupportSpeciesSelector.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import OptionQuantitySelector, { type SelectorOption, type SelectorOptionQuantity } from '@components/analytics/OptionQuantitySelector'
 import { LanguageContext } from '@components/context/LanguageContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import useErrorHandling from '@hooks/ErrorHandlingHook'
 import { TreeType } from '@services/api'
@@ -19,8 +18,7 @@ const SupportSpeciesSelector = ({ onChange, species }: Props) => {
   const { t: translate } = useTranslation()
   const { translateValue } = useContext(LanguageContext)
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [availableSpecies, setAvailableSpecies] = useState<Map<number, TreeType>>(new Map())
   const [options, setOptions] = useState<SelectorOption<number>[]>([])
@@ -43,11 +41,7 @@ const SupportSpeciesSelector = ({ onChange, species }: Props) => {
       setAvailableSpecies(speciesMap)
       setOptions(speciesOptions)
     }
-    fetchTreeSpecies().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-support-species-failed')),
-      )
-    )
+    fetchTreeSpecies().catch(displayUnhandledAPIError('errors.fetch-support-species-failed'))
   }, [])
 
   useEffect(() =>

--- a/canopeum_frontend/src/components/analytics/TreeSpeciesSelector.tsx
+++ b/canopeum_frontend/src/components/analytics/TreeSpeciesSelector.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import OptionQuantitySelector, { type SelectorOption, type SelectorOptionQuantity } from '@components/analytics/OptionQuantitySelector'
 import { LanguageContext } from '@components/context/LanguageContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import useErrorHandling from '@hooks/ErrorHandlingHook'
 import { Species, type TreeType } from '@services/api'
@@ -22,8 +21,7 @@ const TreeSpeciesSelector = (
   const { t: translate } = useTranslation()
   const { translateValue } = useContext(LanguageContext)
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [availableSpecies, setAvailableSpecies] = useState<Map<number, TreeType>>(new Map())
   const [options, setOptions] = useState<SelectorOption<number>[]>([])
@@ -46,11 +44,7 @@ const TreeSpeciesSelector = (
       setAvailableSpecies(speciesMap)
       setOptions(speciesOptions)
     }
-    fetchTreeSpecies().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-tree-species-failed')),
-      )
-    )
+    fetchTreeSpecies().catch(displayUnhandledAPIError('errors.fetch-tree-species-failed'))
   }, [setAvailableSpecies, setOptions])
 
   useEffect(() =>

--- a/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
+++ b/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
@@ -6,7 +6,6 @@ import ImageUpload from '@components/analytics/ImageUpload'
 import SiteCoordinates from '@components/analytics/site-modal/SiteCoordinates'
 import TreeSpeciesSelector from '@components/analytics/TreeSpeciesSelector'
 import { LanguageContext } from '@components/context/LanguageContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import useErrorHandling from '@hooks/ErrorHandlingHook'
 import { type DefaultCoordinate, defaultLatitude, defaultLongitude, extractCoordinate } from '@models/Coordinate'
@@ -48,8 +47,7 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
   const { t } = useTranslation()
   const { getApiClient } = useApiClient()
   const { translateValue } = useContext(LanguageContext)
-  const { getErrorMessage } = useErrorHandling()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [site, setSite] = useState(defaultSiteDto)
   const [availableSiteTypes, setAvailableSiteTypes] = useState<SiteType[]>([])
@@ -97,21 +95,13 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
     const fetchSiteTypes = async () =>
       setAvailableSiteTypes(await getApiClient().siteClient.types())
 
-    fetchSiteTypes().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, t('errors.fetch-site-types-failed')),
-      )
-    )
+    fetchSiteTypes().catch(displayUnhandledAPIError('errors.fetch-site-types-failed'))
   }, [])
 
   useEffect(() => {
     if (!open) return
 
-    fetchSite().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, t('errors.fetch-site-failed')),
-      )
-    )
+    fetchSite().catch(displayUnhandledAPIError('errors.fetch-site-failed'))
   }, [])
 
   useEffect(() => setSite(defaultSiteDto), [siteId])

--- a/canopeum_frontend/src/components/settings/AdminInvitationDialog.tsx
+++ b/canopeum_frontend/src/components/settings/AdminInvitationDialog.tsx
@@ -17,7 +17,7 @@ type Props = {
 const AdminInvitationDialog = ({ open, handleClose }: Props) => {
   const { t: translate } = useTranslation()
   const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { getErrorMessage, displayUnhandledAPIError } = useErrorHandling()
   const { getApiClient } = useApiClient()
 
   const [siteOptions, setSiteOptions] = useState<SelectionItem<number>[]>([])
@@ -36,11 +36,7 @@ const AdminInvitationDialog = ({ open, handleClose }: Props) => {
       setSiteOptions(sites.map(site => ({ displayText: site.name, value: site.id })))
     }
 
-    fetchAllSites().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-all-sites-failed')),
-      )
-    )
+    fetchAllSites().catch(displayUnhandledAPIError('errors.fetch-all-sites-failed'))
   }, [])
   const validateEmail = () => {
     if (!email) {
@@ -78,11 +74,10 @@ const AdminInvitationDialog = ({ open, handleClose }: Props) => {
 
       setInvitationLink(`${globalThis.location.origin}/register?code=${response.code}`)
     } catch (error: unknown) {
-      const errorMessage = getErrorMessage(
+      setGenerateLinkError(getErrorMessage(
         error,
         translate('settings.manage-admins.generate-link-error'),
-      )
-      setGenerateLinkError(errorMessage)
+      ))
     }
   }
 
@@ -92,11 +87,7 @@ const AdminInvitationDialog = ({ open, handleClose }: Props) => {
       .then(() =>
         openAlertSnackbar(`${translate('generic.copied-clipboard')}!`, { severity: 'info' })
       )
-      .catch((error: unknown) =>
-        openAlertSnackbar(
-          getErrorMessage(error, translate('errors.copy-to-clipboard-failed')),
-        )
-      )
+      .catch(displayUnhandledAPIError('errors.copy-to-clipboard-failed'))
   }
 
   const onCloseModal = () => {

--- a/canopeum_frontend/src/components/settings/ManageAdmins.tsx
+++ b/canopeum_frontend/src/components/settings/ManageAdmins.tsx
@@ -1,7 +1,6 @@
-import { useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import AdminCard from '@components/settings/AdminCard'
 import AdminInvitationDialog from '@components/settings/AdminInvitationDialog'
 import useApiClient from '@hooks/ApiClientHook'
@@ -12,8 +11,7 @@ import type { SiteAdmins } from '@services/api'
 const ManageAdmins = () => {
   const { t: translate } = useTranslation()
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [isLoadingAdmins, setIsLoadingAdmins] = useState(true)
   const [siteAdminList, setSiteAdminList] = useState<SiteAdmins[]>([])
@@ -30,11 +28,7 @@ const ManageAdmins = () => {
       }
     }
 
-    fetchSiteAdmins().catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-support-species-failed')),
-      )
-    )
+    fetchSiteAdmins().catch(displayUnhandledAPIError('errors.fetch-support-species-failed'))
   }, [setSiteAdminList, setIsLoadingAdmins])
 
   if (isLoadingAdmins) {

--- a/canopeum_frontend/src/components/social/PostCommentsDialog.tsx
+++ b/canopeum_frontend/src/components/social/PostCommentsDialog.tsx
@@ -29,7 +29,7 @@ const PostCommentsDialog = ({ open, postId, siteId, handleClose }: Props) => {
   const { currentUser } = useContext(AuthenticationContext)
   const { commentChange } = usePostsStore()
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [comments, setComments] = useState<Comment[]>([])
   const [commentsLoaded, setCommentsLoaded] = useState(false)
@@ -50,9 +50,7 @@ const PostCommentsDialog = ({ open, postId, siteId, handleClose }: Props) => {
     fetchComments()
       .then(() => setCommentsLoaded(true))
       .catch((error: unknown) => {
-        openAlertSnackbar(getErrorMessage(error, translate('errors.fetch-comments-failed')), {
-          severity: 'error',
-        })
+        displayUnhandledAPIError('errors.fetch-comments-failed')(error)
         setCommentsLoaded(false)
       })
   }, [postId, open, commentsLoaded, getApiClient])
@@ -138,11 +136,7 @@ const PostCommentsDialog = ({ open, postId, siteId, handleClose }: Props) => {
 
     if (!proceedWithDelete || !commentToDelete) return
 
-    deleteComment(commentToDelete).catch((error: unknown) =>
-      openAlertSnackbar(getErrorMessage(error, translate('errors.delete-comment-failed')), {
-        severity: 'error',
-      })
-    )
+    deleteComment(commentToDelete).catch(displayUnhandledAPIError('errors.delete-comment-failed'))
   }
 
   return (

--- a/canopeum_frontend/src/components/social/SharePostDialog.tsx
+++ b/canopeum_frontend/src/components/social/SharePostDialog.tsx
@@ -16,7 +16,7 @@ type Props = {
 const SharePostDialog = ({ onClose, open, post }: Props) => {
   const { t: translate } = useTranslation()
   const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [shareUrl, setShareUrl] = useState('')
 
@@ -32,12 +32,7 @@ const SharePostDialog = ({ onClose, open, post }: Props) => {
       .then(() =>
         openAlertSnackbar(`${translate('generic.copied-clipboard')}!`, { severity: 'info' })
       )
-      .catch((error: unknown) =>
-        openAlertSnackbar(
-          getErrorMessage(error, translate('errors.copy-to-clibboard-failed')),
-          { severity: 'error' },
-        )
-      )
+      .catch(displayUnhandledAPIError('errors.copy-to-clibboard-failed'))
   }
 
   return (

--- a/canopeum_frontend/src/components/social/site-modal/SiteContactModal.tsx
+++ b/canopeum_frontend/src/components/social/site-modal/SiteContactModal.tsx
@@ -36,22 +36,17 @@ const SiteContactModal = ({ contact, isOpen, handleClose }: Props) => {
   const [isFormValid, setIsFormValid] = useState<boolean>(true)
   const { getApiClient } = useApiClient()
   const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const handleSubmitSiteContact = () =>
-    getApiClient().contactClient.update(contact.id, editedContact as PatchedContact).then(
-      () => {
-        openAlertSnackbar(
-          t('social.contact.feedback.edit-success'),
-        )
+    getApiClient()
+      .contactClient
+      .update(contact.id, editedContact as PatchedContact)
+      .then(() => {
+        openAlertSnackbar(t('social.contact.feedback.edit-success'))
         handleClose(editedContact as Contact)
-      },
-    ).catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, t('social.contact.feedback.edit-error')),
-        { severity: 'error' },
-      )
-    )
+      })
+      .catch(displayUnhandledAPIError('social.contact.feedback.edit-error'))
 
   return (
     <Dialog fullWidth maxWidth='sm' onClose={() => handleClose(null)} open={isOpen}>

--- a/canopeum_frontend/src/hooks/ErrorHandlingHook.tsx
+++ b/canopeum_frontend/src/hooks/ErrorHandlingHook.tsx
@@ -1,10 +1,13 @@
+import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { SnackbarContext } from '@components/context/SnackbarContext'
 import { getApiExceptionMessage } from '@constants/errorMessages'
 import { ApiException } from '@services/api'
 
 const useErrorHandling = () => {
   const { t: translate } = useTranslation()
+  const { openAlertSnackbar } = useContext(SnackbarContext)
 
   const getErrorMessage = (error: unknown, defaultMessage?: string) => {
     defaultMessage ??= translate('generic.error-default')
@@ -20,8 +23,19 @@ const useErrorHandling = () => {
       : defaultMessage
   }
 
+  const displayUnhandledAPIError = (
+    fallbackMessageTranslationKey: string,
+    translationOptions?: Record<string, string | undefined>,
+  ) =>
+  (error: unknown) =>
+    openAlertSnackbar(
+      getErrorMessage(error, translate(fallbackMessageTranslationKey, translationOptions)),
+      { severity: 'error' },
+    )
+
   return {
     getErrorMessage,
+    displayUnhandledAPIError,
   }
 }
 

--- a/canopeum_frontend/src/hooks/PostsInfiniteScrollingHook.tsx
+++ b/canopeum_frontend/src/hooks/PostsInfiniteScrollingHook.tsx
@@ -49,8 +49,7 @@ const usePostsInfiniteScrolling = () => {
       setCurrentPage(previous => previous + 1)
       setLoadingError(undefined)
     } catch (error: unknown) {
-      const errorMessage = getErrorMessage(error, translate('posts.error-loading-posts'))
-      setLoadingError(errorMessage)
+      setLoadingError(getErrorMessage(error, translate('posts.error-loading-posts')))
     }
 
     setIsLoadingFirstPage(false)
@@ -76,7 +75,8 @@ const usePostsInfiniteScrolling = () => {
       return
     }
 
-    fetchPostsPage().then(() => isMounted.current = true)
+    fetchPostsPage()
+      .then(() => isMounted.current = true)
       .catch(() => isMounted.current = false)
   }, [fetchPostsPage, siteIds])
 

--- a/canopeum_frontend/src/i18n.ts
+++ b/canopeum_frontend/src/i18n.ts
@@ -4,7 +4,7 @@ import { initReactI18next } from 'react-i18next'
 
 import resources from './locale'
 
-void i18n
+await i18n
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({

--- a/canopeum_frontend/src/locale/en/auth.ts
+++ b/canopeum_frontend/src/locale/en/auth.ts
@@ -1,5 +1,4 @@
 export default {
-  'user-token-not-found': 'User token not found in storage',
   'keep-password': 'Keep Same Password',
   'change-password': 'Change Password',
   'log-in-header-text': 'Log In to Your Account',

--- a/canopeum_frontend/src/locale/fr/auth.ts
+++ b/canopeum_frontend/src/locale/fr/auth.ts
@@ -1,7 +1,6 @@
 import type Shape from '../en/auth'
 
 export default {
-  'user-token-not-found': "Token de l'usager absent du stockage",
   'keep-password': 'Garder le même mot de passe',
   'change-password': 'Change de mot de passe',
   'log-in-header-text': 'Connectez-vous à votre compte',

--- a/canopeum_frontend/src/pages/Analytics.tsx
+++ b/canopeum_frontend/src/pages/Analytics.tsx
@@ -21,7 +21,7 @@ const Analytics = () => {
   const { openAlertSnackbar } = useContext(SnackbarContext)
   const { currentUser } = useContext(AuthenticationContext)
   const { getApiClient } = useApiClient()
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [siteSummaries, setSiteSummaries] = useState<SiteSummary[]>([])
   const [adminList, setAdminList] = useState<User[]>([])
@@ -135,21 +135,13 @@ const Analytics = () => {
   useEffect((): void => {
     if (currentUser?.role !== 'MegaAdmin') return
 
-    fetchAdmins().catch((error: unknown) =>
-      openAlertSnackbar(getErrorMessage(error, translate('errors.fetch-admins-failed')), {
-        severity: 'error',
-      })
-    )
+    fetchAdmins().catch(displayUnhandledAPIError('errors.fetch-admins-failed'))
   }, [currentUser?.role, fetchAdmins])
 
   useEffect(() => {
     const fetchSites = async () => setSiteSummaries(await getApiClient().summaryClient.all())
 
-    fetchSites().catch((error: unknown) =>
-      openAlertSnackbar(getErrorMessage(error, translate('errors.fetch-fertilizers-failed')), {
-        severity: 'error',
-      })
-    )
+    fetchSites().catch(displayUnhandledAPIError('errors.fetch-fertilizers-failed'))
   }, [getApiClient, setSiteSummaries])
 
   const renderBatches = () =>

--- a/canopeum_frontend/src/pages/AnalyticsSite.tsx
+++ b/canopeum_frontend/src/pages/AnalyticsSite.tsx
@@ -8,7 +8,6 @@ import CreateBatchModal from '@components/analytics/batch-modal/CreateBatchModal
 import BatchTable from '@components/analytics/BatchTable'
 import SiteAdminTabs from '@components/analytics/SiteAdminTabs'
 import { LanguageContext } from '@components/context/LanguageContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import useApiClient from '@hooks/ApiClientHook'
 import useErrorHandling from '@hooks/ErrorHandlingHook'
 import type { SiteSummaryDetail } from '@services/api'
@@ -18,8 +17,7 @@ const AnalyticsSite = () => {
   const { siteId: siteIdFromParams } = useParams()
   const { formatDate } = useContext(LanguageContext)
   const { getApiClient } = useApiClient()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [siteSummary, setSiteSummary] = useState<SiteSummaryDetail | undefined>()
   const [lastModifiedBatchDate, setLastModifiedBatchDate] = useState<Date | undefined>()
@@ -37,12 +35,7 @@ const AnalyticsSite = () => {
     const siteIdNumber = Number.parseInt(siteIdFromParams, 10)
     if (!siteIdNumber) return
 
-    fetchSite(siteIdNumber).catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-site-failed')),
-        { severity: 'error' },
-      )
-    )
+    fetchSite(siteIdNumber).catch(displayUnhandledAPIError('errors.fetch-site-failed'))
   }, [fetchSite, siteIdFromParams])
 
   useEffect(() => {
@@ -105,12 +98,7 @@ const AnalyticsSite = () => {
         handleClose={reason => {
           setIsCreateBatchOpen(false)
           if (reason === 'create') {
-            fetchSite(siteSummary.id).catch((error: unknown) =>
-              openAlertSnackbar(
-                getErrorMessage(error, translate('errors.fetch-site-failed')),
-                { severity: 'error' },
-              )
-            )
+            fetchSite(siteSummary.id).catch(displayUnhandledAPIError('errors.fetch-site-failed'))
           }
         }}
         open={isCreateBatchOpen}

--- a/canopeum_frontend/src/pages/PostDetailsPage.tsx
+++ b/canopeum_frontend/src/pages/PostDetailsPage.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 
 import LoadingPage from './LoadingPage'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import PostCard from '@components/social/PostCard'
 import { appRoutes } from '@constants/routes.constant'
 import useApiClient from '@hooks/ApiClientHook'
@@ -16,8 +15,7 @@ const PostDetailsPage = () => {
   const { postId: postIdFromParams } = useParams()
   const { posts, setPosts } = usePostsStore()
   const { getApiClient } = useApiClient()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [postId, setPostId] = useState<number>()
   const [postDetail, setPostDetail] = useState<Post>()
@@ -58,12 +56,7 @@ const PostDetailsPage = () => {
       return
     }
 
-    fetchPost(postIdNumber).catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-post-failed')),
-        { severity: 'error' },
-      )
-    )
+    fetchPost(postIdNumber).catch(displayUnhandledAPIError('errors.fetch-post-failed'))
     setPostId(postIdNumber)
   }, [fetchPost, postIdFromParams])
 

--- a/canopeum_frontend/src/pages/Register.tsx
+++ b/canopeum_frontend/src/pages/Register.tsx
@@ -6,7 +6,6 @@ import { Link, useSearchParams } from 'react-router-dom'
 
 import AuthPageLayout from '@components/auth/AuthPageLayout'
 import { AuthenticationContext } from '@components/context/AuthenticationContext'
-import { SnackbarContext } from '@components/context/SnackbarContext'
 import { appRoutes } from '@constants/routes.constant'
 import { formClasses } from '@constants/style'
 import useApiClient from '@hooks/ApiClientHook'
@@ -28,8 +27,7 @@ const Register = () => {
   const { authenticate } = useContext(AuthenticationContext)
   const { t: translate } = useTranslation()
   const { getApiClient } = useApiClient()
-  const { openAlertSnackbar } = useContext(SnackbarContext)
-  const { getErrorMessage } = useErrorHandling()
+  const { displayUnhandledAPIError } = useErrorHandling()
 
   const [registrationError, setRegistrationError] = useState<string | undefined>()
   const [codeInvalid, setCodeInvalid] = useState(false)
@@ -91,19 +89,14 @@ const Register = () => {
     const code = searchParams.get('code')
     if (!code) return
 
-    fetchUserInvitation(code).catch((error: unknown) =>
-      openAlertSnackbar(
-        getErrorMessage(error, translate('errors.fetch-user-invitation-failed')),
-        { severity: 'error' },
-      )
-    )
+    fetchUserInvitation(code).catch(displayUnhandledAPIError('errors.fetch-user-invitation-failed'))
   }, [searchParams, fetchUserInvitation])
 
   useEffect(() => {
     const code = searchParams.get('code')
     if (!code) return
 
-    void fetchUserInvitation(code)
+    fetchUserInvitation(code).catch(displayUnhandledAPIError('errors.fetch-user-invitation-failed'))
   }, [searchParams, fetchUserInvitation])
 
   return (


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's Releaf / Canopeum repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests locally (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

All my review items from https://github.com/BesLogic/releaf-canopeum/pull/335 cc @maximeBAY 

There's still probably a lot of network errors we never show to the user because of a `await getApiClient()` where the error isn't explicitly handled. At least those still bubble up as `Error`, and there's no more "floating promises".
I created a separate issue for that: https://github.com/BesLogic/releaf-canopeum/issues/346