### PR TITLE
bugfix: clear dialogs data upon reopening

### DIFF
--- a/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
+++ b/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
@@ -88,7 +88,6 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
     })
     setSiteImageURL(URL.createObjectURL(blob))
     setLoading(false)
-
   }, [siteId, getApiClient])
 
   const onImageUpload = (file: File) => {
@@ -101,7 +100,7 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
       setLoading(true)
       setAvailableSiteTypes(await getApiClient().siteClient.types())
       setLoading(false)
-    }      
+    }
 
     fetchSiteTypes().catch(displayUnhandledAPIError('errors.fetch-site-types-failed'))
   }, [])

--- a/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
+++ b/canopeum_frontend/src/components/analytics/site-modal/SiteModal.tsx
@@ -52,6 +52,7 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
   const [site, setSite] = useState(defaultSiteDto)
   const [availableSiteTypes, setAvailableSiteTypes] = useState<SiteType[]>([])
   const [siteImageURL, setSiteImageURL] = useState<string>()
+  const [loading, setLoading] = useState(true)
 
   const fetchSite = useCallback(async () => {
     if (!siteId) {
@@ -60,6 +61,8 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
 
       return
     }
+
+    setLoading(true)
 
     const siteDetail = await getApiClient().siteClient.detail(siteId)
     const { dmsLatitude, dmsLongitude } = siteDetail.coordinate
@@ -84,6 +87,8 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
       visibleOnMap: siteDetail.visibleMap,
     })
     setSiteImageURL(URL.createObjectURL(blob))
+    setLoading(false)
+
   }, [siteId, getApiClient])
 
   const onImageUpload = (file: File) => {
@@ -92,19 +97,28 @@ const SiteModal = ({ open, handleClose, siteId }: Props) => {
   }
 
   useEffect(() => {
-    const fetchSiteTypes = async () =>
+    const fetchSiteTypes = async () => {
+      setLoading(true)
       setAvailableSiteTypes(await getApiClient().siteClient.types())
+      setLoading(false)
+    }      
 
     fetchSiteTypes().catch(displayUnhandledAPIError('errors.fetch-site-types-failed'))
   }, [])
 
   useEffect(() => {
-    if (!open) return
+    if (!open) {
+      if (!siteId) setSite(defaultSiteDto)
+
+      return
+    }
 
     fetchSite().catch(displayUnhandledAPIError('errors.fetch-site-failed'))
-  }, [])
+  }, [siteId])
 
   useEffect(() => setSite(defaultSiteDto), [siteId])
+
+  if (loading) return null
 
   return (
     <Dialog fullWidth maxWidth='sm' onClose={(_, reason) => handleClose(reason)} open={open}>

--- a/canopeum_frontend/src/components/social/PostCommentsDialog.tsx
+++ b/canopeum_frontend/src/components/social/PostCommentsDialog.tsx
@@ -42,7 +42,12 @@ const PostCommentsDialog = ({ open, postId, siteId, handleClose }: Props) => {
 
   useEffect(() => {
     // Since this is a dialog, we only want to fetch the comments once it is opened
-    if (!open || commentsLoaded) return
+    if (!open || commentsLoaded) {
+      setCommentBody('')
+      setCommentBodyNumberOfChars(0)
+      setCommentBodyError(undefined)
+      return
+    }
 
     const fetchComments = async () => setComments(await getApiClient().commentClient.all(postId))
 

--- a/canopeum_frontend/src/components/social/site-modal/SiteAnnouncementModal.tsx
+++ b/canopeum_frontend/src/components/social/site-modal/SiteAnnouncementModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material'
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SnackbarContext } from '@components/context/SnackbarContext'
@@ -26,6 +26,10 @@ const SiteAnnouncementModal = ({ announcement, isOpen, handleClose }: Props) => 
   const [isFormValid, setIsFormValid] = useState<boolean>(true)
   const { getApiClient } = useApiClient()
   const { openAlertSnackbar } = useContext(SnackbarContext)
+
+  useEffect(() => {
+    if (!isOpen) setEditedAnnouncement(announcement)
+  }, [isOpen, announcement])
 
   const handleSubmitSiteAnnouncement = async () => {
     try {

--- a/canopeum_frontend/src/components/social/site-modal/SiteContactModal.tsx
+++ b/canopeum_frontend/src/components/social/site-modal/SiteContactModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material'
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import facebookLogo from '@assets/icons/facebook-contact-logo.svg'
@@ -37,6 +37,10 @@ const SiteContactModal = ({ contact, isOpen, handleClose }: Props) => {
   const { getApiClient } = useApiClient()
   const { openAlertSnackbar } = useContext(SnackbarContext)
   const { displayUnhandledAPIError } = useErrorHandling()
+
+  useEffect(() => {
+    if (!isOpen) setEditedContact(contact)
+  }, [isOpen, contact])
 
   const handleSubmitSiteContact = () =>
     getApiClient()


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's Releaf / Canopeum repo.
Before submitting this PR, please make sure:
-->

- [x] The project passes automated tests locally (build, linting, etc.).
- [x] You updated the project's documentation with new changes.
- [x] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [x] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [x] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Fixed dialogs that were not clearing previous data properly upon loading: Site, Comments, SiteAnnoucement, SiteContact

Also investigated rest of dialogs and the others were behaving the proper way

Closes #316