### PR TITLE
Gracefully fallback on `googlemaps.exceptions.ApiError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ On Linux you must instal the mysql dev binaries to be able to build the `mysqlcl
    GOOGLE_API_KEY_CANOPEUM=<your Google Geocoding API key, leave empty if none>
    ```
 
+   Management for the Google API Key can be accessed here: <https://console.cloud.google.com/google/maps-apis/credentials?project=canopeum-dev-api-key>
+
    4.2. Then run:
 
    ```shell


### PR DESCRIPTION
<!--
Thank you for your contribution to Beslogic's Releaf / Canopeum repo.
Before submitting this PR, please make sure:
-->

- [ ] The project passes automated tests locally (build, linting, etc.).
- [ ] You updated the project's documentation with new changes.
- [ ] You've [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) any issue this PR closes
- [ ] You reviewed your own PR and made sure there's no test/debug code or any obvious mistakes.

Make sure that the code wasn't copied from elsewhere (check one):

- [ ] This is your own original code
- [ ] You have made sure that we have permission to use the copied code and that we follow its licensing

Gracefully fallback on `googlemaps.exceptions.ApiError`

![Image](https://github.com/user-attachments/assets/3ca22a9d-8aae-4968-be5a-caae87cb660b) 
![Image](https://github.com/user-attachments/assets/9951cd85-e8a9-4220-ad96-fc2e850416fc)

I checked the Google Dashboard and it seems the issue is that Google updated how these APIs work (now under "API Places (nouvelle version)"). I've re-applied the restrictions to the new key to only be valid for Geocoding services. And I've updated the ENV key in GitHub Environments.

Locally you'll need to update your key (or leaving it empty will work like before for local development)